### PR TITLE
Use HTTPS for packages

### DIFF
--- a/Composed-Demo.xcodeproj/project.pbxproj
+++ b/Composed-Demo.xcodeproj/project.pbxproj
@@ -494,7 +494,7 @@
 /* Begin XCRemoteSwiftPackageReference section */
 		545BF60B242FD62C00996ACC /* XCRemoteSwiftPackageReference "ComposedMediaUI" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "git@github.com:composed-swift/ComposedMediaUI.git";
+			repositoryURL = "https://github.com/composed-swift/ComposedMediaUI.git";
 			requirement = {
 				branch = master;
 				kind = branch;
@@ -518,7 +518,7 @@
 		};
 		548D9C3B242FA0190059E42B /* XCRemoteSwiftPackageReference "ComposedMedia" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "git@github.com:composed-swift/ComposedMedia.git";
+			repositoryURL = "https://github.com/composed-swift/ComposedMedia.git";
 			requirement = {
 				branch = master;
 				kind = branch;
@@ -526,7 +526,7 @@
 		};
 		54F68E97231098A600C0319E /* XCRemoteSwiftPackageReference "ComposedUI" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "git@github.com:composed-swift/ComposedUI.git";
+			repositoryURL = "https://github.com/composed-swift/ComposedUI.git";
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 1.0.0;
@@ -534,7 +534,7 @@
 		};
 		54F68E9C23109BF600C0319E /* XCRemoteSwiftPackageReference "FlowLayout" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "git@github.com:shaps80/FlowLayout.git";
+			repositoryURL = "https://github.com/shaps80/FlowLayout.git";
 			requirement = {
 				branch = master;
 				kind = branch;

--- a/Composed-Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Composed-Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,8 +2,26 @@
   "object": {
     "pins": [
       {
+        "package": "ComposedMedia",
+        "repositoryURL": "https://github.com/composed-swift/ComposedMedia.git",
+        "state": {
+          "branch": "master",
+          "revision": "0f9078c8217b2c9e5327e9dc759e4147f0e6af13",
+          "version": null
+        }
+      },
+      {
+        "package": "ComposedMediaUI",
+        "repositoryURL": "https://github.com/composed-swift/ComposedMediaUI.git",
+        "state": {
+          "branch": "master",
+          "revision": "11fee5095158f879301acf70238e4856a3413eca",
+          "version": null
+        }
+      },
+      {
         "package": "FlowLayout",
-        "repositoryURL": "git@github.com:shaps80/FlowLayout.git",
+        "repositoryURL": "https://github.com/shaps80/FlowLayout.git",
         "state": {
           "branch": "master",
           "revision": "88766cd84246481c665d410f01182da31f7296f3",


### PR DESCRIPTION
Xcode does not support ed25519 SSH keys so if a user uses ed25519 keys to authenticate with GitHub the connection will fail. HTTPS does not require authentication (for public repos)